### PR TITLE
Fix theme color

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -163,7 +163,14 @@ function notify(message, sender) {
         //console.log('Setting index ' + message.value + ' from next page..');
         pendingApplyColor = themeProposal.colors;
         indexedColorMap[sender.tab.url] = pendingApplyColor;
-        util_custom_update(themeProposal);
+
+        // update the theme, if the message came from the active tab
+        var gettingActiveTab = browser.tabs.query({active: true, currentWindow: true});
+        gettingActiveTab.then(function(activeTabs) {
+          if (activeTabs[0] === sender) {
+            util_custom_update(themeProposal);
+           }
+        });
     }
   }
 }

--- a/src/background.js
+++ b/src/background.js
@@ -167,7 +167,7 @@ function notify(message, sender) {
         // update the theme, if the message came from the active tab
         var gettingActiveTab = browser.tabs.query({active: true, currentWindow: true});
         gettingActiveTab.then(function(activeTabs) {
-          if (activeTabs[0] === sender) {
+          if (activeTabs[0].id === sender.tab.id) {
             util_custom_update(themeProposal);
            }
         });


### PR DESCRIPTION
When a tab opens in the background, its content script is still going to send the theme-color message – therefore, theme-color of tabs opened in the background were applied.
This patch fixes this behavior.